### PR TITLE
Fix crasher bug, extract more information

### DIFF
--- a/src/devicecode_fetch_fcc.py
+++ b/src/devicecode_fetch_fcc.py
@@ -36,9 +36,10 @@ def main(fccids, output_directory, grantees, verbose, force, gentle):
         sys.exit(1)
 
     fcc_grantees = set()
-    with open(grantees, 'r') as grantee:
-        for g in grantee:
-            fcc_grantees.add(g.strip())
+    if grantees is not None:
+        with open(grantees, 'r') as grantee:
+            for g in grantee:
+                fcc_grantees.add(g.strip())
 
     ids = []
 


### PR DESCRIPTION
This fixes a crasher bug that would happen if the FCC id grantee list was not supplied. It also extracts some more information from texts extracted from the PDFs.